### PR TITLE
openshift-tasks: chapter 1 (#3)

### DIFF
--- a/openshift-tasks/src/openshift.1.5.status.md
+++ b/openshift-tasks/src/openshift.1.5.status.md
@@ -10,6 +10,8 @@
 * [Monitoring application health](https://docs.openshift.com/container-platform/4.2/applications/application-health.html)
 * [Viewing and listing the nodes in your OpenShift Container Platform cluster](https://docs.openshift.com/container-platform/4.2/nodes/nodes/nodes-nodes-viewing.html)
 * [Viewing system event information in an OpenShift Container Platform cluster](https://docs.openshift.com/container-platform/4.2/nodes/clusters/nodes-containers-events.html)
+* [DeploymentConfigs](https://docs.openshift.com/container-platform/4.2/applications/deployments/what-deployments-are.html#deployments-and-deploymentconfigs_what-deployments-are)
+
 
 ## Tasks
 
@@ -21,6 +23,7 @@
 * Get stastus of all nodes
 * Create directory and dump cluster information into it. Get logs of on of the 
     **myproject/django-psql-example** Pods from the dump
-* Get information about deployments from the dump. Get all deployments using `oc` tool
+* Get information about deploymentConfigs from the dump. Get all deploymentConfigs using `oc` tool
     and output them into JSON. Are these JSONs the same?
-* Describe deployments via `oc`. Is the information the same as in the previous case?
+* Describe deploymentConfig via `oc`. Is the information the same as in the previous case?
+

--- a/openshift-tasks/src/openshift.1.6.logs.md
+++ b/openshift-tasks/src/openshift.1.6.logs.md
@@ -17,5 +17,9 @@
 * View deployment logs via `oc` tool
 * View log of individual redis pods via `oc` tool
 * Log into Web Console and get the same logs via GUI
+
+**Use CRC for the following tasks since PG has a StorageClass problem**
+
+
 * Deploy cluster logging
 * Get logs from **fluentd**


### PR DESCRIPTION
* OS-tasks: link to CRC installation description

* OS-tasks: remove references

deleted Getting started with the CLI and Enable autocompletion as OpenShift CLI (OC) has the same content

* OS-tasks: OS Playground link 

openshift.1.1.cli.md: added OpenShift Playground link for quick access

* OS-tasks: OS Playground link

* OS Playground link

* OS-tasks: reference & tasks

- added links to reference Info
- added links to deploying application from images and source

* return deleted link

* 1.5.status: deployments-->deploymentConfigs

* Update openshift.1.6.logs.md

1.6.logs: add recommendation

* Update openshift.1.6.logs.md

* Revert "Update openshift.1.6.logs.md"

This reverts commit 7402d40ba058578453328e27b4b927b7fc211152.

* Update openshift.1.6.logs.md

* Revert "Update openshift.1.6.logs.md"

This reverts commit 7402d40ba058578453328e27b4b927b7fc211152.